### PR TITLE
Fix PyPI publish workflow to run in Linux environment

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -117,15 +117,14 @@ jobs:
           path: dist/
           if-no-files-found: error
 
-  # Release to PyPI
-  release-to-pypi:
-    name: Release
+  # Prepare Release
+  prepare-release:
+    name: Prepare Release
     needs: [build-and-test]
     if: github.event_name == 'release' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
     runs-on: windows-latest
     permissions:
       contents: write
-      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -164,6 +163,32 @@ jobs:
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Upload artifacts for PyPI publishing
+      - name: Upload artifacts for PyPI
+        uses: actions/upload-artifact@v4
+        with:
+          name: pypi-dist
+          path: dist/
+          if-no-files-found: error
+          retention-days: 1
+
+  # Publish to PyPI
+  publish-to-pypi:
+    name: Publish to PyPI
+    needs: [prepare-release]
+    if: github.event_name == 'release' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Download artifacts for PyPI
+        uses: actions/download-artifact@v4
+        with:
+          name: pypi-dist
+          path: dist
+      # List all artifacts
+      - name: List all artifacts
+        run: find dist -type f | sort
       # Publish to PyPI
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # Photoshop MCP Server
 
+[![PyPI Version](https://img.shields.io/pypi/v/photoshop-mcp-server.svg)](https://pypi.org/project/photoshop-mcp-server/)
+[![PyPI Downloads](https://img.shields.io/pypi/dm/photoshop-mcp-server.svg)](https://pypi.org/project/photoshop-mcp-server/)
+[![Build Status](https://github.com/loonghao/photoshop-python-api-mcp-server/actions/workflows/python-publish.yml/badge.svg)](https://github.com/loonghao/photoshop-python-api-mcp-server/actions/workflows/python-publish.yml)
+[![License](https://img.shields.io/github/license/loonghao/photoshop-python-api-mcp-server.svg)](https://github.com/loonghao/photoshop-python-api-mcp-server/blob/main/LICENSE)
+[![Python Version](https://img.shields.io/pypi/pyversions/photoshop-mcp-server.svg)](https://pypi.org/project/photoshop-mcp-server/)
+[![Platform](https://img.shields.io/badge/platform-windows-lightgrey.svg)](https://github.com/loonghao/photoshop-python-api-mcp-server)
+[![GitHub stars](https://img.shields.io/github/stars/loonghao/photoshop-python-api-mcp-server.svg)](https://github.com/loonghao/photoshop-python-api-mcp-server/stargazers)
+[![GitHub issues](https://img.shields.io/github/issues/loonghao/photoshop-python-api-mcp-server.svg)](https://github.com/loonghao/photoshop-python-api-mcp-server/issues)
+[![GitHub last commit](https://img.shields.io/github/last-commit/loonghao/photoshop-python-api-mcp-server.svg)](https://github.com/loonghao/photoshop-python-api-mcp-server/commits/main)
+
 A Model Context Protocol (MCP) server for Photoshop integration using photoshop-python-api.
+
+English | [简体中文](README_zh.md)
 
 ## Overview
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,0 +1,110 @@
+# Photoshop MCP 服务器
+
+[![PyPI Version](https://img.shields.io/pypi/v/photoshop-mcp-server.svg)](https://pypi.org/project/photoshop-mcp-server/)
+[![PyPI Downloads](https://img.shields.io/pypi/dm/photoshop-mcp-server.svg)](https://pypi.org/project/photoshop-mcp-server/)
+[![Build Status](https://github.com/loonghao/photoshop-python-api-mcp-server/actions/workflows/python-publish.yml/badge.svg)](https://github.com/loonghao/photoshop-python-api-mcp-server/actions/workflows/python-publish.yml)
+[![License](https://img.shields.io/github/license/loonghao/photoshop-python-api-mcp-server.svg)](https://github.com/loonghao/photoshop-python-api-mcp-server/blob/main/LICENSE)
+[![Python Version](https://img.shields.io/pypi/pyversions/photoshop-mcp-server.svg)](https://pypi.org/project/photoshop-mcp-server/)
+[![Platform](https://img.shields.io/badge/platform-windows-lightgrey.svg)](https://github.com/loonghao/photoshop-python-api-mcp-server)
+[![GitHub stars](https://img.shields.io/github/stars/loonghao/photoshop-python-api-mcp-server.svg)](https://github.com/loonghao/photoshop-python-api-mcp-server/stargazers)
+[![GitHub issues](https://img.shields.io/github/issues/loonghao/photoshop-python-api-mcp-server.svg)](https://github.com/loonghao/photoshop-python-api-mcp-server/issues)
+[![GitHub last commit](https://img.shields.io/github/last-commit/loonghao/photoshop-python-api-mcp-server.svg)](https://github.com/loonghao/photoshop-python-api-mcp-server/commits/main)
+
+一个使用 photoshop-python-api 的 Photoshop 集成的模型上下文协议 (MCP) 服务器。
+
+[English](README.md) | 简体中文
+
+## 概述
+
+本项目提供了模型上下文协议 (MCP) 和 Adobe Photoshop 之间的桥梁，允许 AI 助手和其他 MCP 客户端以编程方式控制 Photoshop。
+
+## 要求
+
+- **仅支持 Windows 系统**：此服务器使用 COM 接口，仅在 Windows 上可用
+- **Adobe Photoshop**：必须在本地安装（已测试 CC2017 至 2024 版本）
+- **Python**：版本 3.10 或更高
+
+## 安装
+
+```bash
+# 使用 pip 安装
+pip install photoshop-mcp-server
+
+# 或使用 uv
+uv install photoshop-mcp-server
+```
+
+## MCP 主机配置
+
+此服务器设计为与各种 MCP 主机一起工作。`PS_VERSION` 环境变量用于指定要连接的 Photoshop 版本（例如，"2024"、"2023"、"2022" 等）。
+
+推荐使用 `uvx` 作为命令来配置服务器，这是官方标准格式。
+
+### 标准配置（推荐）
+
+将以下内容添加到您的 MCP 主机配置中（适用于 Claude Desktop、Windsurf、Cline 和其他 MCP 主机）：
+
+```json
+{
+  "mcpServers": {
+    "photoshop": {
+      "command": "uvx",
+      "args": ["ps-mcp"],
+      "env": {
+        "PS_VERSION": "2024"
+      }
+    }
+  }
+}
+```
+
+### 配置选项
+
+- **PS_VERSION**：指定要连接的 Photoshop 版本（例如，"2024"、"2023"、"2022" 等）
+- **command**：使用 `uvx` 作为标准方法
+- **args**：使用 `["ps-mcp"]` 运行 Photoshop MCP 服务器
+
+## 主要功能
+
+### 可用资源
+
+- `photoshop://info` - 获取 Photoshop 应用程序信息
+- `photoshop://document/info` - 获取活动文档信息
+- `photoshop://document/layers` - 获取活动文档中的图层
+
+### 可用工具
+
+服务器提供了各种控制 Photoshop 的工具：
+
+- **文档工具**：创建、打开和保存文档
+- **图层工具**：创建文本图层、纯色图层等
+- **会话工具**：获取有关 Photoshop 会话、活动文档、选择的信息
+
+## 基本使用示例
+
+一旦在 MCP 主机中配置好，您就可以在 AI 助手对话中使用 Photoshop MCP 服务器。
+
+![Photoshop MCP 服务器演示](assets/ps-mcp.gif)
+
+示例对话：
+
+```text
+用户：能否创建一个新的 Photoshop 文档并添加一个带有"Hello World"的文本图层？
+
+AI 助手：我将为您创建一个新文档并添加文本图层。
+
+[AI 使用 Photoshop MCP 服务器：
+1. 使用 `create_document` 工具创建新文档
+2. 使用 `create_text_layer` 工具添加文本为"Hello World"的文本图层]
+
+我已创建了一个新的 Photoshop 文档并添加了一个带有"Hello World"的文本图层。
+```
+
+## 许可证
+
+MIT
+
+## 致谢
+
+- [photoshop-python-api](https://github.com/loonghao/photoshop-python-api) - Photoshop 的 Python API
+- [Model Context Protocol](https://github.com/modelcontextprotocol/python-sdk) - MCP Python SDK


### PR DESCRIPTION
## Problem

The current GitHub Actions workflow fails when trying to publish to PyPI because the `pypa/gh-action-pypi-publish@release/v1` action can only run in GNU/Linux environments, while our workflow is configured to run in a Windows environment.

Error message:
```
This action is only able to run under GNU/Linux environments
```

## Solution

Split the release process into two jobs:
1. `prepare-release`: Runs in Windows environment, responsible for preparing release files and updating GitHub Release
2. `publish-to-pypi`: Runs in Linux environment, specifically responsible for publishing to PyPI

With this change, the build and test still run on Windows (as the project is Windows-specific), but the final PyPI publishing step runs in a Linux environment, meeting the requirements of the `pypa/gh-action-pypi-publish` action.

## Testing

This fix should allow the GitHub Actions workflow to successfully publish the package to PyPI when creating new release tags.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author