### PR TITLE
Fix get_active_document_info to return actual layer data

### DIFF
--- a/photoshop_mcp_server/ps_adapter/action_manager.py
+++ b/photoshop_mcp_server/ps_adapter/action_manager.py
@@ -150,8 +150,35 @@ class ActionManager:
             except Exception as e:
                 print(f"Error getting document path: {e}")
 
-            # Get layers info would require more complex Action Manager code
-            # This is a simplified implementation
+            # Layer information is easier and more reliable through the DOM API.
+            # Use it as a companion to the Action Manager document metadata above.
+            try:
+                doc = ps_app.get_active_document()
+                if doc:
+                    for i, layer in enumerate(doc.artLayers):
+                        is_background = bool(getattr(layer, "isBackgroundLayer", False))
+                        if is_background:
+                            continue
+
+                        result["layers"].append(
+                            {
+                                "index": i,
+                                "name": getattr(layer, "name", ""),
+                                "visible": getattr(layer, "visible", True),
+                                "kind": str(getattr(layer, "kind", "Unknown")),
+                            }
+                        )
+
+                    for i, layer_set in enumerate(doc.layerSets):
+                        result["layer_sets"].append(
+                            {
+                                "index": i,
+                                "name": getattr(layer_set, "name", ""),
+                                "visible": getattr(layer_set, "visible", True),
+                            }
+                        )
+            except Exception as e:
+                print(f"Error getting layer info: {e}")
 
             return result
 


### PR DESCRIPTION
This PR fixes `get_active_document_info` so it returns real layer information instead of always returning empty `layers` and `layer_sets` arrays.

## What changed
- Added layer extraction from the active Photoshop document via the DOM API (`doc.artLayers`).
- Added layer set extraction via `doc.layerSets`.
- Kept existing Action Manager-based document metadata logic intact.
- Excluded background layer from the returned `layers` list so the count matches visible/user content layers in typical workflows.

## Why
The session tool `get_active_document_info` was reporting zero layers even when layers existed in the active document, which made layer-related diagnostics and automation unreliable.

## Validation
- Before fix: MCP response returned empty `layers` on a document known to contain layers.
- After fix: MCP response correctly returned the layer list and count (validated against an active document with expected layers).

## Notes
- This change is scoped to active document info reporting only.
- No behavior changes to document creation/editing tools.